### PR TITLE
Update TerraformingUtilities.java

### DIFF
--- a/src/kentington/diyplanets/TerraformingUtilities.java
+++ b/src/kentington/diyplanets/TerraformingUtilities.java
@@ -27,7 +27,7 @@ public class TerraformingUtilities {
 		PlanetGenDataSpec genData=(PlanetGenDataSpec)Global.getSettings().getSpec(PlanetGenDataSpec.class, planetType, false);
 		String planetCat = genData.getCategory();
 		
-		if(!planet.getPlanetEntity().isStar() && !planet.getPlanetEntity().isGasGiant() && !planet.hasCondition("habitable") && !planet.hasCondition("very_cold") && !planet.hasCondition("very_hot") && !planet.hasCondition("no_atmosphere") && !planet.hasCondition("thin_atmosphere") && !planet.hasCondition("toxic_atmosphere") && !planet.hasCondition("irradiated") && !planet.hasCondition("dark"))
+		if(!planet.getPlanetEntity().isStar() && !planet.getPlanetEntity().isGasGiant() && !planet.hasCondition("habitable") && !planet.hasCondition("very_cold") && !planet.hasCondition("very_hot") && !planet.hasCondition("no_atmosphere") && !planet.hasCondition("thin_atmosphere") && !planet.hasCondition("toxic_atmosphere") && !planet.hasCondition("irradiated") && !planet.hasCondition("dark") && !planetType.equals("Volcanic") && !planetType.equals("Cryovolcanic") &&  !planetType.equals("rocky_ice") && !planetType.equals("frozen") && !planetType.equals("Toxic") && !planetType.equals("Barren") && !planetType.equals("Barren-desert"))
 		{
 			planet.addCondition("habitable");
 		}


### PR DESCRIPTION
Some planet types should be excluded from the habitable condition. Currently there are ways to get the habitable condition on planets that shouldn't have it. for example it is possible to get habitable condition on a cryovolcanic world with tectonic activity and cold/extreme cold by just removing the cold/extreme cold condition. In this case the planet type stays as cryovolcanic but habitable condition will be added. There could be other ways to get the habitable condition on a planet type that shouldn't have it. This is why I propose " a blacklist" to prevent certain planet types from getting it. In the code are the planet types I think should not be able to get the habitable condition. If you dont agree, you are free to change them.