### PR TITLE
Update TerraformShipBarEvent.java

### DIFF
--- a/src/kentington/diyplanets/TerraformShipBarEvent.java
+++ b/src/kentington/diyplanets/TerraformShipBarEvent.java
@@ -46,6 +46,7 @@ public class TerraformShipBarEvent extends BaseGetCommodityBarEvent {
 			if (system.hasTag(Tags.THEME_CORE_POPULATED)) continue;
 			if (system.hasTag(Tags.THEME_REMNANT_MAIN)) continue;
 			if (system.hasTag(Tags.THEME_REMNANT_RESURGENT)) continue;
+			if (system.isNebula()) continue;
 			
 			float sinceVisit = Global.getSector().getClock().getElapsedDaysSince(system.getLastPlayerVisitTimestamp());
 			if (sinceVisit < 60) continue;


### PR DESCRIPTION
Modifies doConfirmActionsPreAcceptText() to add code that skips nebula systems when iterating through star systems to pick a target for spawning the terraforming core.

Should hopefully fix the NullPointerException encountered when using getRadius() on a system that lacks a star (causing getStar() to be NULL).

(See https://fractalsoftworks.com/forum/index.php?topic=27992.msg468137#msg468137 for reference)